### PR TITLE
Searching should add user's name to URL

### DIFF
--- a/css/afchistory.css
+++ b/css/afchistory.css
@@ -26,7 +26,7 @@ a:hover {
     text-decoration: underline;
 }
 
-#permalink {
+#start-over {
     font-size: smaller;
 }
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <br />
     <output id="error" style="display: none;"></output>
     <output id="result" style="display: none;">
-      <div id="permalink"></div>
+      <div id="start-over"></div>
       <div id="statistics"></div>
       <div id="checkbox-filters">
         Filter:


### PR DESCRIPTION
- Submitting now updates the URL to include the searched username
- Page title now includes the searched username, for neater browser history
    - <img width="177" alt="2024-04-11_013343" src="https://github.com/enterprisey/afchistory/assets/79697282/91d06320-a966-446e-ad27-e5bdfb303314">
- Delete "permalink to these results". No longer needed now that we can copy the permalink URL from the browser's URL bar
- Add "start over" link so we can easily reach the homepage
    - <img width="164" alt="2024-04-11_013449" src="https://github.com/enterprisey/afchistory/assets/79697282/ea617d35-7642-4496-8897-10b6c7973ba7">
- Refactoring

Fixes #9

